### PR TITLE
evdi_gem: Fix null pointer deference

### DIFF
--- a/module/evdi_gem.c
+++ b/module/evdi_gem.c
@@ -211,6 +211,9 @@ static void evdi_gem_put_pages(struct evdi_gem_object *obj)
 
 int evdi_gem_vmap(struct evdi_gem_object *obj)
 {
+#if KERNEL_VERSION(5, 11, 0) <= LINUX_VERSION_CODE
+	struct dma_buf_map map;
+#endif
 	int page_count = obj->base.size / PAGE_SIZE;
 	int ret;
 
@@ -218,7 +221,8 @@ int evdi_gem_vmap(struct evdi_gem_object *obj)
 #if LINUX_VERSION_CODE < KERNEL_VERSION(5, 11, 0)
 		obj->vmapping = dma_buf_vmap(obj->base.import_attach->dmabuf);
 #else
-		dma_buf_vmap(obj->base.import_attach->dmabuf, obj->vmapping);
+		dma_buf_vmap(obj->base.import_attach->dmabuf, &map);
+		obj->vmapping = map.vaddr;
 #endif
 		if (!obj->vmapping)
 			return -ENOMEM;


### PR DESCRIPTION
Fix the null pointer deference from obj->vmapping:

```
[ 3316.038155] evdi: [D] evdi_painter_dpms_notify:654 (dev=0) Notifying dpms mode: 0
[ 3316.047829] BUG: kernel NULL pointer dereference, address: 0000000000000008
[ 3316.047833] #PF: supervisor read access in kernel mode
[ 3316.047834] #PF: error_code(0x0000) - not-present page
[ 3316.047836] PGD 800000014b017067 P4D 800000014b017067 PUD 14b28c067 PMD 0 
[ 3316.047840] Oops: 0000 [#3] SMP PTI
[ 3316.047843] CPU: 5 PID: 11217 Comm: ThreadedDevice_ Tainted: G      D W  O      5.11.0-rc5-MicroHobby+ #5
[ 3316.047845] Hardware name: SAMSUNG ELECTRONICS CO., LTD. 800G5M/800G5W/NP800G5M-XG2BR, BIOS P11RDV.075.170829.XJ 08/29/2017
[ 3316.047846] RIP: 0010:dma_buf_vmap+0x2a/0x120
[ 3316.047850] Code: 0f 1f 44 00 00 55 48 89 e5 41 56 41 55 41 54 49 89 f4 53 48 89 fb 48 83 ec 18 65 48 8b 04 25 28 00 00 00 48 89 44 24 10 31 c0 <80> 7e 08 00 48 c7 06 00 00 00 00 74 04 c6 46 08 00 48 85 db 0f 84
[ 3316.047852] RSP: 0018:ffff9eca4209fc48 EFLAGS: 00010246
[ 3316.047854] RAX: 0000000000000000 RBX: ffff90dbcb2ed000 RCX: 0000000000000000
[ 3316.047856] RDX: ffff90dbb5a70000 RSI: 0000000000000000 RDI: ffff90dbcb2ed000
[ 3316.047857] RBP: ffff9eca4209fc80 R08: 0000000000000000 R09: 0000000000000000
[ 3316.047858] R10: ffff90db9abee040 R11: 0000000000000438 R12: 0000000000000000
[ 3316.047860] R13: ffff9eca4209fd00 R14: ffff90db9abee000 R15: ffff90db8a019200
[ 3316.047861] FS:  00007f9b1b7fe640(0000) GS:ffff90e29ed40000(0000) knlGS:0000000000000000
[ 3316.047863] CS:  0010 DS: 0000 ES: 0000 CR0: 0000000080050033
[ 3316.047864] CR2: 0000000000000008 CR3: 0000000128274001 CR4: 00000000003706e0
[ 3316.047866] Call Trace:
[ 3316.047867]  ? __ext4_journal_stop+0x3c/0xb0
[ 3316.047873]  evdi_gem_vmap+0x2a/0xd0 [evdi]
[ 3316.047879]  evdi_painter_grabpix_ioctl+0x42c/0x520 [evdi]
[ 3316.047883]  ? generic_perform_write+0x133/0x1c0
```

Signed-off-by: Matheus Castello <matheus@castello.eng.br>

